### PR TITLE
Add contributors modal with dynamic loading

### DIFF
--- a/assets/app.css
+++ b/assets/app.css
@@ -103,7 +103,6 @@ html, body {
     letter-spacing: 0.2px;
 }
 
-/* Small note (e.g., BETA) next to the title, aligned to the top text line */
 .title .beta {
     font-size: 0.6em;
     line-height: 1;
@@ -262,10 +261,10 @@ html[data-theme="dark"] .station-marker {
     background-color: var(--label-bg);
     padding: 2px 5px;
     border-radius: 3px;
-        font-size: var(--station-label-font-size, 11px);
+    font-size: var(--station-label-font-size, 11px);
     white-space: nowrap;
     /* default position above the marker; can be overridden by label-pos-* */
-        transform: translate(-50%, calc(-1 * var(--station-label-offset, 120%)));
+    transform: translate(-50%, calc(-1 * var(--station-label-offset, 120%)));
     pointer-events: none;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
     opacity: 0.6;
@@ -388,6 +387,7 @@ html[data-theme="dark"] .station-marker {
     -webkit-user-select: none;
     user-select: none;
 }
+
 html[data-theme="dark"] #map-controls {
     background: rgba(23, 26, 33, 0.70);
 }
@@ -417,6 +417,7 @@ html[data-theme="dark"] #map-controls {
     background: var(--accent-soft-hover);
     border-color: var(--accent);
 }
+
 .zoom-btn:focus-visible {
     outline: none;
     box-shadow: 0 0 0 2px var(--accent-ring);
@@ -869,8 +870,6 @@ main {
     color: var(--muted);
 }
 
-/* (export modal and print styles removed) */
-
 /* Cards and wrappers */
 .map-section {
     background: var(--panel);
@@ -1035,18 +1034,182 @@ main {
     border: 0;
 }
 
-/* (Editor shape overlay removed) */
+/* Contributors modal */
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .2s ease-in-out;
+    z-index: 1300;
+}
 
-/* Editor: missing refinements for rows/inputs/actions */
-/* (Editor inputs and rows removed) */
+.modal-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+}
 
-/* (Editor generated markers removed) */
+.modal {
+    position: fixed;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .2s ease-in-out;
+    z-index: 1301;
+    /* above overlay */
+    padding: 16px;
+}
 
-/* (Editor line list UI removed) */
+.modal.open {
+    opacity: 1;
+    pointer-events: auto;
+}
 
-/* (Editor line properties removed) */
+.modal-content {
+    width: min(720px, 100%);
+    max-height: min(80vh, 100%);
+    background: rgba(255, 255, 255, 0.85);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    box-shadow: var(--shadow);
+    -webkit-backdrop-filter: saturate(180%) blur(10px);
+    backdrop-filter: saturate(180%) blur(10px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
 
-/* (Editor chooser removed) */
+.modal-content .modal-header {
+    background: transparent;
+}
+
+html[data-theme="dark"] .modal-content {
+    background: rgba(23, 26, 33, 0.70);
+}
+
+.modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border);
+}
+
+.modal-title {
+    margin: 0;
+    font-size: 18px;
+    line-height: 1.2;
+}
+
+.modal-close {
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    align-self: center;
+    background: var(--control-bg);
+    color: var(--control-text);
+    border: 1px solid var(--border);
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0;
+    -webkit-appearance: none;
+    appearance: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    -webkit-tap-highlight-color: transparent;
+    transition: background-color 140ms ease, border-color 140ms ease, box-shadow 140ms ease, color 140ms ease;
+}
+
+.modal-close:hover {
+    background: var(--accent-soft-hover);
+    border-color: var(--accent);
+}
+
+.modal-close:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--accent-ring), 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+/* On mobile keep a larger touch target */
+@media (max-width: 520px) {
+    .modal-close {
+        width: 32px;
+        height: 32px;
+        font-size: 18px;
+    }
+}
+
+.modal-body {
+    padding: 16px 20px 14px 20px;
+    overflow: auto;
+}
+
+.modal-body #contributors-content {
+    background: var(--panel);
+    color: inherit;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    box-shadow: var(--shadow);
+    padding: 14px 16px;
+}
+
+.modal-body #contributors-content p {
+    margin: 0 0 8px;
+}
+
+.modal-body #contributors-content ul {
+    margin: 8px 0 0 18px;
+}
+
+.modal-body #contributors-content li {
+    margin: 4px 0;
+}
+
+.modal-body h2 {
+    font-size: 16px;
+    margin: 8px 0;
+}
+
+.modal-body h3 {
+    font-size: 14px;
+    margin: 6px 0;
+    opacity: .9;
+}
+
+.no-scroll {
+    overflow: hidden;
+}
+
+/* Footer contributors trigger — make it look like a subtle link */
+.site-footer .btn-secondary,
+.site-footer .link-plain {
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: var(--muted);
+    text-decoration: underline;
+    border-radius: 0;
+}
+
+.site-footer .btn-secondary:hover,
+.site-footer .link-plain:hover {
+    color: var(--text);
+    text-decoration-color: var(--text);
+}
+
+.site-footer .btn-secondary:focus-visible,
+.site-footer .link-plain:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px var(--accent-ring);
+    border-radius: 6px;
+}
 
 /* Server status widget */
 .mc-status {
@@ -1073,8 +1236,6 @@ main {
 .mc-status.offline .dot {
     background: #c62828;
 }
-
-/* (Editor blocker removed) */
 
 /* PWA install banner */
 .pwa-banner {
@@ -1160,7 +1321,7 @@ main {
         right: 0;
         bottom: 0;
         border-radius: 12px 12px 0 0;
-    /* square bottom corners */
+        /* square bottom corners */
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }

--- a/assets/contributors.js
+++ b/assets/contributors.js
@@ -1,0 +1,80 @@
+(function () {
+    // Simple accessible modal that loads contributors.md and renders as preformatted text (Markdown kept as-is)
+    const openBtn = document.getElementById("contributors-open");
+    const modal = document.getElementById("contributors-modal");
+    const overlay = document.getElementById("contributors-overlay");
+    const content = document.getElementById("contributors-content");
+    const titleEl = document.getElementById("contributors-title");
+    const closeBtn = document.getElementById("contributors-close");
+    if (!openBtn || !modal || !overlay || !content || !closeBtn) return;
+
+    let lastActive = null;
+
+    async function loadContributors() {
+        try {
+            const res = await fetch("/contributors.md", { cache: "no-store" });
+            if (!res.ok) throw new Error("HTTP " + res.status);
+            const raw = await res.text();
+            // Split lines; first non-empty line becomes modal title (strip leading markdown #)
+            const lines = raw.split(/\r?\n/);
+            let first = lines.length ? lines[0] : "";
+            if (/^\s*#/.test(first)) first = first.replace(/^\s*#+\s*/, "");
+            const body = lines.slice(1).join("\n");
+            if (titleEl) titleEl.textContent = first || "Autorzy i wkład";
+            // Minimal MD-to-HTML for body
+            const html = body
+                .replace(/^## (.*)$/gm, "<h3>$1</h3>")
+                .replace(/^\- (.*)$/gm, "<li>$1</li>")
+                .replace(/(^|\n)(<li>)/g, "$1<ul>$2")
+                .replace(/(<\/li>)(?!\n<li>)/g, "$1</ul>");
+            content.innerHTML = html.trim();
+        } catch (e) {
+            content.textContent = "Nie udało się wczytać listy autorów.";
+        }
+    }
+
+    function open() {
+        lastActive = document.activeElement;
+        modal.classList.add("open");
+        overlay.classList.add("open");
+        modal.setAttribute("aria-hidden", "false");
+        overlay.setAttribute("aria-hidden", "false");
+        // load content on first open
+        if (!content.getAttribute("data-loaded")) {
+            loadContributors().then(() =>
+                content.setAttribute("data-loaded", "1")
+            );
+        }
+        // focus the close button
+        closeBtn.focus();
+        document.body.classList.add("no-scroll");
+    }
+    function close() {
+        modal.classList.remove("open");
+        overlay.classList.remove("open");
+        modal.setAttribute("aria-hidden", "true");
+        overlay.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("no-scroll");
+        if (lastActive && lastActive.focus) {
+            try {
+                lastActive.focus();
+            } catch {}
+        }
+    }
+
+    function onKey(e) {
+        if (e.key === "Escape") {
+            close();
+        }
+    }
+    function onOverlay(e) {
+        if (e.target === overlay) {
+            close();
+        }
+    }
+
+    openBtn.addEventListener("click", open);
+    closeBtn.addEventListener("click", close);
+    overlay.addEventListener("click", onOverlay);
+    document.addEventListener("keydown", onKey);
+})();

--- a/contributors.md
+++ b/contributors.md
@@ -1,0 +1,6 @@
+# Autorzy i wkład
+
+Przedstawiamy listę osób zaangażowanych w projekt ZTKweb:
+
+- Miersetnik - aplikacja internetowa i koordynacja projektu
+- NKacz - pliki graficzne ZTK, mapa świata, mapa polityczna, lista stacji i linii

--- a/export.html
+++ b/export.html
@@ -116,6 +116,25 @@
       </section>
     </div>
   </main>
+  <footer class="site-footer" role="contentinfo">
+    <div class="container footer-inner">
+      <div class="footer-left">
+        <button id="contributors-open" class="link-plain btn-secondary" aria-haspopup="dialog" aria-controls="contributors-modal">Autorzy i wkład</button>
+      </div>
+      <div class="footer-right">Strona nie jest w żaden sposób powiązana z firmą Microsoft, Mojang lub grą Minecraft.</div>
+    </div>
+  </footer>
+  <!-- Contributors modal -->
+  <div id="contributors-overlay" class="modal-overlay" aria-hidden="true"></div>
+  <div id="contributors-modal" class="modal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="contributors-title">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2 id="contributors-title" class="modal-title">Autorzy i wkład</h2>
+        <button id="contributors-close" class="modal-close" aria-label="Zamknij">×</button>
+      </div>
+      <div id="contributors-content" class="modal-body" data-loaded=""></div>
+    </div>
+  </div>
   <script src="assets/map-zoom.js"></script>
   <script src="assets/map-renderer.js"></script>
   <script src="assets/legend-renderer.js"></script>
@@ -123,6 +142,7 @@
   <script src="assets/pwa-install.js"></script>
   <script src="assets/vendor/html2pdf.bundle.min.js"></script>
   <script src="assets/export-page.js"></script>
+  <script src="assets/contributors.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {

--- a/index.html
+++ b/index.html
@@ -119,10 +119,23 @@
     </main>
         <footer class="site-footer" role="contentinfo">
             <div class="container footer-inner">
-                <div class="footer-left">Aplikację stworzył Miersetnik.<br>Mapy dostarczył NKacz.</div>
+                <div class="footer-left">
+                    <button id="contributors-open" class="link-plain btn-secondary" aria-haspopup="dialog" aria-controls="contributors-modal">Autorzy i wkład</button>
+                </div>
                 <div class="footer-right">Strona nie jest w żaden sposób powiązana z firmą Microsoft, Mojang lub grą Minecraft.</div>
             </div>
         </footer>
+        <!-- Contributors modal -->
+        <div id="contributors-overlay" class="modal-overlay" aria-hidden="true"></div>
+        <div id="contributors-modal" class="modal" role="dialog" aria-modal="true" aria-hidden="true" aria-labelledby="contributors-title">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h2 id="contributors-title" class="modal-title">Autorzy i wkład</h2>
+                    <button id="contributors-close" class="modal-close" aria-label="Zamknij">×</button>
+                </div>
+                <div id="contributors-content" class="modal-body" data-loaded=""></div>
+            </div>
+        </div>
     <script src="assets/map-zoom.js"></script>
     <script src="assets/map-renderer.js"></script>
     <script src="assets/route-search.js"></script>
@@ -132,6 +145,7 @@
     <script src="assets/theme-toggle.js"></script>
     <script src="assets/map-layers.js"></script>
     <script src="assets/pwa-install.js"></script>
+    <script src="assets/contributors.js"></script>
         <script>
             if ('serviceWorker' in navigator) {
                 window.addEventListener('load', () => {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'ztkweb-v5';
+const CACHE_VERSION = 'ztkweb-v6';
 const STATIC_CACHE = CACHE_VERSION + '-static';
 const DATA_CACHE = CACHE_VERSION + '-data';
 const REMOTE_CACHE = CACHE_VERSION + '-remote';
@@ -19,6 +19,7 @@ const STATIC_ASSETS = [
   '/assets/theme-toggle.js',
   '/assets/map-layers.js',
   '/assets/pwa-install.js',
+  '/assets/contributors.js',
   '/assets/vendor/html2pdf.bundle.min.js',
   '/assets/logo_ztk.png',
   '/assets/favicon.png',
@@ -30,7 +31,8 @@ const STATIC_ASSETS = [
 ];
 const DATA_ASSETS = [
   '/assets/stations.json',
-  '/assets/lines.json'
+  '/assets/lines.json',
+  '/contributors.md'
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
Introduces a modal dialog for displaying project contributors, accessible from the site footer. The modal loads and renders contributors.md dynamically using a new contributors.js script, with supporting styles added to app.css. Footer markup in index.html and export.html is updated to trigger the modal, and sw.js is updated to cache the new assets for offline support.